### PR TITLE
Update HeaderValueMatches.java

### DIFF
--- a/src/main/java/com/michelin/kafka/connect/transforms/predicates/HeaderValueMatches.java
+++ b/src/main/java/com/michelin/kafka/connect/transforms/predicates/HeaderValueMatches.java
@@ -7,6 +7,7 @@ import org.apache.kafka.connect.transforms.predicates.Predicate;
 import org.apache.kafka.connect.transforms.util.RegexValidator;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -58,6 +59,17 @@ public class HeaderValueMatches<R extends ConnectRecord<R>> implements Predicate
         // Loop over headers (multiple with same name allowed)
         while (headerIterator.hasNext()) {
             Header header = headerIterator.next();
+            final Object valueAsObject = header.value();
+            final String valueAsString;
+            if (valueAsObject != null) {
+                if (valueAsObject instanceof byte[]) {
+                    valueAsString = new String((byte[]) valueAsObject, StandardCharsets.UTF_8);
+                } else {
+                    valueAsString = valueAsObject.toString();
+                }
+            } else {
+                valueAsString = null;
+            }
             if (header.value() != null && pattern.matcher(header.value().toString()).matches()) {
                 return true;
             }


### PR DESCRIPTION
Sans précision de header.converter, les valeurs de headers sont par défaut encodées en base64 => la comparaison entre la regex en clair et la valeur du header en base64 ne peut jamais être vraie.

En présence d'un header.converter de type ByteArrayConverter, la valeur est bien conservée sans transco mais la comparaison entre la regex et un byte[].toString ne peut aussi jamais être vraie.

Le patch permet de comparer correctement les contenus passant par un ByteArrayConverter converter.