### PR TITLE
Added the ability to decrypt AES256 text encrypted by the standard AP…

### DIFF
--- a/doc/config-providers/aes256-config-provider.md
+++ b/doc/config-providers/aes256-config-provider.md
@@ -11,14 +11,18 @@ Nice to have when using Kafka Connect in a multi-tenant environment.
     config.providers.aes256.class=com.michelin.kafka.AES256ConfigProvider
     config.providers.aes256.param.key=0000111122223333
     config.providers.aes256.param.salt=0000111122223333
-    ````
-2. Provide an API to your users so that they can encrypt their passwords with your key  
-   https://github.com/twobeeb/aes-256-vault-api
+    ````  
+   
+2. Use NS4Kafka to encrypt your password, or provide an API to your users so that they can encrypt their passwords with your key
+   * NS4Kafka: https://github.com/michelin/kafkactl/blob/main/README.md
+   * AES256 API: https://github.com/twobeeb/aes-256-vault-api  
+
+
 3. Keep your key safe !
 
 ## Connector configuration
 
-Encode your password using API:
+Encode your password using the AES256 API:
 ````console
 curl -X POST http://admin-api/vault -d '{"password": "mypassword"}'
 > ${aes256:mfw43l96122yZiDhu2RevQ==}

--- a/src/test/java/com/michelin/kafka/config/providers/AES256ConfigProviderTest.java
+++ b/src/test/java/com/michelin/kafka/config/providers/AES256ConfigProviderTest.java
@@ -62,6 +62,33 @@ class AES256ConfigProviderTest {
     }
 
     @Test
+    void DecryptSuccessBothAlgorithm() {
+        final var originalPassword = "hello !";
+        final var encodedPassword = "hgkWF2Gp3qPxcPnVifDgJA==";
+        final var encodedPasswordNS4K1 = "TlM0SxO5N1cXueLtuDRVEBCAacMVm/4dwYN0/SMjKGlnkNXFDDt7";
+        final var encodedPasswordNS4K2 = "TlM0S9g7l18K6q6pTXs5NGVL2vRVDyHbQ6NDliGPh6UlgL4+6MEX";
+        try (final var configProvider = new AES256ConfigProvider()) {
+            final var configs = new HashMap<String, String>();
+            configs.put("key", "key-aaaabbbbccccdddd");
+            configs.put("salt", "salt-aaaabbbbccccdddd");
+            configProvider.configure(configs);
+
+            // String encoded = AES256Helper.encrypt("aaaabbbbccccdddd",AES256ConfigProvider.DEFAULT_SALT, originalPassword);
+            // System.out.println(encoded);
+
+            final var rightKeys = new HashSet<String>();
+            rightKeys.add(encodedPassword);
+            rightKeys.add(encodedPasswordNS4K1);
+            rightKeys.add(encodedPasswordNS4K2);
+
+            var result = configProvider.get("", rightKeys).data();
+            assertEquals(originalPassword, result.get(encodedPassword));
+            assertEquals(originalPassword, result.get(encodedPasswordNS4K1));
+            assertEquals(originalPassword, result.get(encodedPasswordNS4K2));
+        }
+    }
+
+    @Test
     void MissingConfig_key() {
         try (final var configProvider = new AES256ConfigProvider()) {
             final var configs = new HashMap<String, String>();


### PR DESCRIPTION
This functionality allows the use of NS4KAFKA Connect Cluster vaulting new functionality.
It will detect if the secret has been encrypted by [NS4KAFKA ](https://github.com/michelin/ns4kafka)or by the [API](https://github.com/twobeeb/aes-256-vault-api), and decrypt the secret according to the right algorithm 

 