### PR TITLE
Adding new ExpandJsonHeaders SMT

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Copy `michelin-connect-plugins.jar` into the ``plugin.path`` folder of your Kafk
 
 ## Transformations
   - [TimestampMicrosConverter](doc/transforms/timestamp-micros-converter.md)
+  - [ExpandJsonHeaders](doc/transforms/expand-json-headers.md)
 ## Predicates
   - [HeaderValueMatches](doc/predicates/header-value-matches.md)
 ## Config Providers

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,10 @@ dependencies {
 
     // Use JUnit Jupiter for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
+
+    // Dependencies provided by Kafka Connect
+    compileOnly 'com.fasterxml.jackson.core:jackson-databind:2.19.0'
+    compileOnly 'org.slf4j:slf4j-api:1.7.36'
 }
 java {
     sourceCompatibility = '11'

--- a/doc/transforms/expand-json-headers.md
+++ b/doc/transforms/expand-json-headers.md
@@ -1,0 +1,83 @@
+# Expand JSON Headers SMT
+
+A Kafka Connect Single Message Transform (SMT) that takes an existing JSON header and expands each key-value pair into separate individual Kafka message headers. The original JSON header is removed after expansion.
+
+## Use Case
+
+This transform is particularly useful when working with transactional outbox patterns where you have JSON data in a Kafka header that you want to expand into individual headers for better message routing and filtering.
+
+For example, if you have a Kafka header named `headers` containing:
+```json
+{"userId": "user123", "requestId": "req456", "source": "web"}
+```
+
+This SMT will:
+1. Extract each key-value pair and create individual headers:
+    - `userId` = "user123"
+    - `requestId` = "req456"
+    - `source` = "web"
+2. Remove the original `headers` header
+
+## Configuration
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `header.field` | String | `headers` | Header name containing the JSON map |
+
+## Usage with Debezium EventRouter
+
+```json
+{
+  "name": "outbox-connector-with-headers",  
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "database.hostname": "localhost",
+    "database.port": "5432",
+    "database.user": "postgres",
+    "database.password": "postgres",
+    "database.dbname": "postgres",
+    "plugin.name": "pgoutput",
+    "table.include.list": "public.outbox_messages",
+    "transforms": "outbox,addHeaders,expandHeaders",
+    "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
+    "transforms.outbox.table.expand.json.payload": "true",
+    "transforms.outbox.table.field.event.key": "partition_key",
+    "transforms.outbox.route.by.field": "topic",
+    "transforms.outbox.route.topic.replacement": "${routedByValue}",
+    "transforms.outbox.table.fields.additional.placement": "headers:headers",
+    "transforms.expandHeaders.type": "com.michelin.connect.transforms.ExpandJsonHeaders",
+    "transforms.expandHeaders.header.field": "headers",
+    "value.converter": "io.confluent.connect.avro.AvroConverter",
+    "value.converter.schema.registry.url": "http://schema-registry:8085"
+  }
+}
+```
+## Examples
+
+### Basic Usage
+```json
+"transforms": "expandHeaders",
+"transforms.expandHeaders.type": "com.michelin.connect.transforms.ExpandJsonHeaders"
+```
+
+### With Custom Field Name
+```json
+"transforms": "expandHeaders",
+"transforms.expandHeaders.type": "com.michelin.connect.transforms.ExpandJsonHeaders",
+"transforms.expandHeaders.header.field": "metadata"
+```
+
+## Behavior
+
+- **Input**: A Kafka header containing JSON map data
+- **Processing**: Parses the JSON and creates individual headers for each key-value pair
+- **Output**: Individual headers with the original JSON header removed
+- **Error Handling**: If the header is missing, invalid JSON, or not a JSON object, the record is passed through unchanged
+
+## Error Handling
+
+The transform is designed to be resilient:
+- If the specified header is missing, the record is passed through unchanged
+- If the JSON is invalid, the record is passed through unchanged
+- If the header is not a JSON object, the record is passed through unchanged
+- Errors are logged but do not cause the connector to fail

--- a/src/main/java/com/michelin/kafka/connect/transforms/ExpandJsonHeaders.java
+++ b/src/main/java/com/michelin/kafka/connect/transforms/ExpandJsonHeaders.java
@@ -1,0 +1,115 @@
+package com.michelin.kafka.connect.transforms;
+
+import java.util.NoSuchElementException;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * <p>Kafka Connect Single Message Transform (SMT) that takes an existing JSON header
+ * and expands each key-value pair into separate individual Kafka message headers.
+ * The original JSON header is removed after expansion.</p>
+ *
+ * <p>This transform is useful when you have JSON content in a header that you want
+ * to split into multiple headers for better message routing and filtering.</p>
+ *
+ * <p>Configuration:
+ * <ul>
+ *     <li>header.field: Header name containing the JSON map (default: "headers")</li>
+ * </ul></p>
+ */
+public class ExpandJsonHeaders<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    private static final Logger log = LoggerFactory.getLogger(ExpandJsonHeaders.class);
+
+    private static final String HEADER_FIELD_CONFIG = "header.field";
+    private static final String HEADER_FIELD_DEFAULT = "headers";
+
+    public static final ConfigDef CONFIG_DEF = new ConfigDef()
+        .define(HEADER_FIELD_CONFIG, ConfigDef.Type.STRING, HEADER_FIELD_DEFAULT,
+            ConfigDef.Importance.HIGH, "Header name containing the JSON map");
+
+    private String headerField;
+    private ObjectMapper objectMapper;
+
+    @Override
+    public void configure(Map<String, ?> props) {
+        final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
+        headerField = config.getString(HEADER_FIELD_CONFIG);
+        objectMapper = new ObjectMapper();
+
+        log.info("Configured ExpandJsonHeaders with field='{}'", headerField);
+    }
+
+    @Override
+    public R apply(R record) {
+        Headers headers = record.headers();
+
+        try {
+            Header headerValue = headers.allWithName(headerField).next();
+
+            JsonNode jsonNode = objectMapper.readTree(headerValue.value().toString());
+
+            if (!jsonNode.isObject()) {
+                log.warn("Field '{}' is not a JSON object, skipping header extraction", headerField);
+                return record;
+            }
+
+            Iterator<Map.Entry<String, JsonNode>> fields = jsonNode.fields();
+
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> field = fields.next();
+                String headerName = field.getKey();
+                String headerValueStr = field.getValue().asText();
+                headers.addString(headerName, headerValueStr);
+                log.debug("Added header: {} = {}", headerName, headerValueStr);
+            }
+
+            log.debug("Successfully extracted headers from field '{}'", headerField);
+
+            // Remove the original JSON header after expansion
+            headers.remove(headerField);
+            log.debug("Removed original header '{}'", headerField);
+        } catch (NoSuchElementException e) {
+            log.debug("No '{}' field found in record, skipping header extraction", headerField);
+            // Return original record if field is not found
+            return record;
+        } catch (Exception e) {
+            log.warn("Failed to parse JSON from field '{}': {}", headerField, e.getMessage());
+            // Return original record on parsing errors
+            return record;
+        }
+
+        return record.newRecord(
+            record.topic(),
+            record.kafkaPartition(),
+            record.keySchema(),
+            record.key(),
+            record.valueSchema(),
+            record.value(),
+            record.timestamp(),
+            headers
+        );
+    }
+
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    @Override
+    public void close() {
+        // No resources to close
+    }
+}

--- a/src/test/java/com/michelin/kafka/connect/transforms/ExpandJsonHeadersTest.java
+++ b/src/test/java/com/michelin/kafka/connect/transforms/ExpandJsonHeadersTest.java
@@ -1,0 +1,233 @@
+package com.michelin.kafka.connect.transforms;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExpandJsonHeadersTest {
+
+    private ExpandJsonHeaders<SourceRecord> transform;
+
+    @BeforeEach
+    void setUp() {
+        transform = new ExpandJsonHeaders<>();
+    }
+
+    @Test
+    void testConfigureWithDefaults() {
+        Map<String, Object> config = new HashMap<>();
+        transform.configure(config);
+
+        assertNotNull(transform);
+    }
+
+    @Test
+    void testConfigureWithCustomValues() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("header.field", "custom_headers");
+
+        transform.configure(config);
+
+        assertNotNull(transform);
+    }
+
+    @Test
+    void testExpandJsonHeaderWithMultipleFields() {
+        // Configure transform
+        Map<String, Object> config = new HashMap<>();
+        transform.configure(config);
+
+        // Create record with JSON header
+        Headers headers = new ConnectHeaders();
+        headers.addString("headers", "{\"userId\":\"user123\",\"requestId\":\"req456\",\"source\":\"web\"}");
+
+        SourceRecord record = new SourceRecord(
+            null, null, "test-topic", null, null, null, Schema.STRING_SCHEMA, "test-value", null, headers
+        );
+
+        // Apply transform
+        SourceRecord transformed = transform.apply(record);
+
+        // Verify expanded headers were added
+        Headers transformedHeaders = transformed.headers();
+        assertNotNull(transformedHeaders);
+
+        assertEquals("user123", getHeaderValue(transformedHeaders, "userId"));
+        assertEquals("req456", getHeaderValue(transformedHeaders, "requestId"));
+        assertEquals("web", getHeaderValue(transformedHeaders, "source"));
+
+        // Verify original header was removed
+        assertNull(getHeaderValue(transformedHeaders, "headers"));
+    }
+
+    @Test
+    void testExpandJsonHeaderWithCustomFieldName() {
+        // Configure transform with custom field name
+        Map<String, Object> config = new HashMap<>();
+        config.put("header.field", "metadata");
+        transform.configure(config);
+
+        // Create record with JSON header using custom field name
+        Headers headers = new ConnectHeaders();
+        headers.addString("metadata", "{\"version\":\"1.0\",\"type\":\"event\"}");
+
+        SourceRecord record = new SourceRecord(
+            null, null, "test-topic", null, null, null, Schema.STRING_SCHEMA, "test-value", null, headers
+        );
+
+        // Apply transform
+        SourceRecord transformed = transform.apply(record);
+
+        // Verify headers were expanded
+        Headers transformedHeaders = transformed.headers();
+        assertNotNull(transformedHeaders);
+
+        assertEquals("1.0", getHeaderValue(transformedHeaders, "version"));
+        assertEquals("event", getHeaderValue(transformedHeaders, "type"));
+
+        // Verify original header was removed
+        assertNull(getHeaderValue(transformedHeaders, "metadata"));
+    }
+
+    @Test
+    void testExpandEmptyJsonHeader() {
+        // Configure transform
+        Map<String, Object> config = new HashMap<>();
+        transform.configure(config);
+
+        // Create record with empty JSON header
+        Headers headers = new ConnectHeaders();
+        headers.addString("headers", "{}");
+
+        SourceRecord record = new SourceRecord(
+            null, null, "test-topic", null, null, null, Schema.STRING_SCHEMA, "test-value", null, headers
+        );
+
+        // Apply transform
+        SourceRecord transformed = transform.apply(record);
+
+        // Should have removed the original header even if empty
+        Headers transformedHeaders = transformed.headers();
+        assertNotNull(transformedHeaders);
+        assertNull(getHeaderValue(transformedHeaders, "headers"));
+    }
+
+    @Test
+    void testMissingHeaderField() {
+        // Configure transform
+        Map<String, Object> config = new HashMap<>();
+        transform.configure(config);
+
+        // Create record without the expected header
+        Headers headers = new ConnectHeaders();
+        headers.addString("other_header", "some_value");
+
+        SourceRecord record = new SourceRecord(
+            null, null, "test-topic", null, null, null, Schema.STRING_SCHEMA, "test-value", null, headers
+        );
+
+        // Apply transform
+        SourceRecord transformed = transform.apply(record);
+
+        // Should return original record unchanged
+        assertEquals(record.value(), transformed.value());
+        assertEquals("some_value", getHeaderValue(transformed.headers(), "other_header"));
+    }
+
+    @Test
+    void testInvalidJsonHeader() {
+        // Configure transform
+        Map<String, Object> config = new HashMap<>();
+        transform.configure(config);
+
+        // Create record with invalid JSON
+        Headers headers = new ConnectHeaders();
+        headers.addString("headers", "invalid json {");
+
+        SourceRecord record = new SourceRecord(
+            null, null, "test-topic", null, null, null, Schema.STRING_SCHEMA, "test-value", null, headers
+        );
+
+        // Apply transform
+        SourceRecord transformed = transform.apply(record);
+
+        // Should not throw exception and should return original record
+        assertNotNull(transformed);
+        assertEquals(record.value(), transformed.value());
+        // Original header should still be present since parsing failed
+        assertEquals("invalid json {", getHeaderValue(transformed.headers(), "headers"));
+    }
+
+    @Test
+    void testNonObjectJsonHeader() {
+        // Configure transform
+        Map<String, Object> config = new HashMap<>();
+        transform.configure(config);
+
+        // Create record with JSON array instead of object
+        Headers headers = new ConnectHeaders();
+        headers.addString("headers", "[\"item1\", \"item2\"]");
+
+        SourceRecord record = new SourceRecord(
+            null, null, "test-topic", null, null, null, Schema.STRING_SCHEMA, "test-value", null, headers
+        );
+
+        // Apply transform
+        SourceRecord transformed = transform.apply(record);
+
+        // Should not expand array and should return original record
+        assertNotNull(transformed);
+        assertEquals(record.value(), transformed.value());
+        // Original header should still be present since it's not an object
+        assertEquals("[\"item1\", \"item2\"]", getHeaderValue(transformed.headers(), "headers"));
+    }
+
+    @Test
+    void testComplexJsonValues() {
+        // Configure transform
+        Map<String, Object> config = new HashMap<>();
+        transform.configure(config);
+
+        // Create record with complex JSON values (nested objects, arrays, etc.)
+        Headers headers = new ConnectHeaders();
+        headers.addString("headers", "{\"simple\":\"value\",\"number\":42,\"boolean\":true,\"nested\":{\"key\":\"value\"}}");
+
+        SourceRecord record = new SourceRecord(
+            null, null, "test-topic", null, null, null, Schema.STRING_SCHEMA, "test-value", null, headers
+        );
+
+        // Apply transform
+        SourceRecord transformed = transform.apply(record);
+
+        // Verify all values are converted to strings
+        Headers transformedHeaders = transformed.headers();
+        assertNotNull(transformedHeaders);
+
+        assertEquals("value", getHeaderValue(transformedHeaders, "simple"));
+        assertEquals("42", getHeaderValue(transformedHeaders, "number"));
+        assertEquals("true", getHeaderValue(transformedHeaders, "boolean"));
+        // For nested objects, Jackson's asText() returns the toString() representation
+        assertNotNull(getHeaderValue(transformedHeaders, "nested")); // Just check it exists
+
+        // Verify original header was removed
+        assertNull(getHeaderValue(transformedHeaders, "headers"));
+    }
+
+    private String getHeaderValue(Headers headers, String key) {
+        for (Header header : headers) {
+            if (header.key().equals(key)) {
+                return (String) header.value();
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
A Kafka Connect Single Message Transform (SMT) that takes an existing JSON header and expands each key-value pair into separate individual Kafka message headers. The original JSON header is removed after expansion.

This transform is for instance useful when working with transactional outbox patterns where you have column containing headers in a JSON map that you want to expand into individual headers